### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "purescript-random":        "~0.1.1",
     "purescript-exceptions":    "~0.2.2",
-    "purescript-arrays":        "~0.2.1",
-    "purescript-strings":       "~0.4.1",
+    "purescript-arrays":        "~0.3.0",
+    "purescript-strings":       "~0.4.2",
     "purescript-math":          "~0.1.0",
-    "purescript-tuples":        "~0.2.2",
+    "purescript-tuples":        "~0.2.3",
     "purescript-either":        "~0.1.4",
     "purescript-maybe":         "~0.2.1",
     "purescript-foldable-traversable": "~0.1.4"


### PR DESCRIPTION
purescript-quickcheck doesn't use STArray, so it should be just a minor version bump.
