### PR TITLE
Minimal QC (discussion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,97 +196,6 @@ data Gen a
 ```
 
 
-#### `repeatable`
-
-``` purescript
-repeatable :: forall a b. (a -> Gen b) -> Gen (a -> b)
-```
-
-
-#### `stateful`
-
-``` purescript
-stateful :: forall a. (GenState -> Gen a) -> Gen a
-```
-
-
-#### `variant`
-
-``` purescript
-variant :: forall a. LCG -> Gen a -> Gen a
-```
-
-
-#### `sized`
-
-``` purescript
-sized :: forall a. (Size -> Gen a) -> Gen a
-```
-
-
-#### `resize`
-
-``` purescript
-resize :: forall a. Size -> Gen a -> Gen a
-```
-
-
-#### `choose`
-
-``` purescript
-choose :: Number -> Number -> Gen Number
-```
-
-
-#### `chooseInt`
-
-``` purescript
-chooseInt :: Number -> Number -> Gen Number
-```
-
-
-#### `oneOf`
-
-``` purescript
-oneOf :: forall a. Gen a -> [Gen a] -> Gen a
-```
-
-
-#### `frequency`
-
-``` purescript
-frequency :: forall a. Tuple Number (Gen a) -> [Tuple Number (Gen a)] -> Gen a
-```
-
-
-#### `arrayOf`
-
-``` purescript
-arrayOf :: forall a. Gen a -> Gen [a]
-```
-
-
-#### `arrayOf1`
-
-``` purescript
-arrayOf1 :: forall a. Gen a -> Gen (Tuple a [a])
-```
-
-
-#### `vectorOf`
-
-``` purescript
-vectorOf :: forall a. Number -> Gen a -> Gen [a]
-```
-
-
-#### `elements`
-
-``` purescript
-elements :: forall a. a -> [a] -> Gen a
-```
-
-
 #### `runGen`
 
 ``` purescript
@@ -301,17 +210,17 @@ evalGen :: forall a. Gen a -> GenState -> a
 ```
 
 
-#### `showSample'`
+#### `repeatable`
 
 ``` purescript
-showSample' :: forall r a. (Show a) => Size -> Gen a -> Eff (trace :: Trace | r) Unit
+repeatable :: forall a b. (a -> Gen b) -> Gen (a -> b)
 ```
 
 
-#### `showSample`
+#### `stateful`
 
 ``` purescript
-showSample :: forall r a. (Show a) => Gen a -> Eff (trace :: Trace | r) Unit
+stateful :: forall a. (GenState -> Gen a) -> Gen a
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -2,233 +2,17 @@
 
 ## Module Test.QuickCheck
 
-#### `Arbitrary`
-
-``` purescript
-class Arbitrary t where
-  arbitrary :: Gen t
-```
-
-
-#### `CoArbitrary`
-
-``` purescript
-class CoArbitrary t where
-  coarbitrary :: forall r. t -> Gen r -> Gen r
-```
-
-
-#### `Result`
-
-``` purescript
-data Result
-  = Success 
-  | Failed String
-```
-
-
-#### `showResult`
-
-``` purescript
-instance showResult :: Show Result
-```
-
-
-#### `(<?>)`
-
-``` purescript
-(<?>) :: Boolean -> String -> Result
-```
-
-
-#### `arbChar`
-
-``` purescript
-instance arbChar :: Arbitrary S.Char
-```
-
-
-#### `coarbChar`
-
-``` purescript
-instance coarbChar :: CoArbitrary S.Char
-```
-
-
-#### `arbNumber`
-
-``` purescript
-instance arbNumber :: Arbitrary Number
-```
-
-
-#### `coarbNumber`
-
-``` purescript
-instance coarbNumber :: CoArbitrary Number
-```
-
-
-#### `arbBoolean`
-
-``` purescript
-instance arbBoolean :: Arbitrary Boolean
-```
-
-
-#### `coarbBoolean`
-
-``` purescript
-instance coarbBoolean :: CoArbitrary Boolean
-```
-
-
-#### `arbString`
-
-``` purescript
-instance arbString :: Arbitrary String
-```
-
-
-#### `coarbString`
-
-``` purescript
-instance coarbString :: CoArbitrary String
-```
-
-
-#### `AlphaNumString`
-
-``` purescript
-newtype AlphaNumString
-  = AlphaNumString String
-```
-
-
-#### `arbAlphaNumString`
-
-``` purescript
-instance arbAlphaNumString :: Arbitrary AlphaNumString
-```
-
-
-#### `coarbAlphaNumString`
-
-``` purescript
-instance coarbAlphaNumString :: CoArbitrary AlphaNumString
-```
-
-
-#### `arbTuple`
-
-``` purescript
-instance arbTuple :: (Arbitrary a, Arbitrary b) => Arbitrary (Tuple a b)
-```
-
-
-#### `coarbTuple`
-
-``` purescript
-instance coarbTuple :: (CoArbitrary a, CoArbitrary b) => CoArbitrary (Tuple a b)
-```
-
-
-#### `arbEither`
-
-``` purescript
-instance arbEither :: (Arbitrary a, Arbitrary b) => Arbitrary (Either a b)
-```
-
-
-#### `coarbEither`
-
-``` purescript
-instance coarbEither :: (CoArbitrary a, CoArbitrary b) => CoArbitrary (Either a b)
-```
-
-
-#### `arbMaybe`
-
-``` purescript
-instance arbMaybe :: (Arbitrary a) => Arbitrary (Maybe a)
-```
-
-
-#### `coarbMaybe`
-
-``` purescript
-instance coarbMaybe :: (CoArbitrary a) => CoArbitrary (Maybe a)
-```
-
-
-#### `arbFunction`
-
-``` purescript
-instance arbFunction :: (CoArbitrary a, Arbitrary b) => Arbitrary (a -> b)
-```
-
-
-#### `coarbFunction`
-
-``` purescript
-instance coarbFunction :: (Arbitrary a, CoArbitrary b) => CoArbitrary (a -> b)
-```
-
-
-#### `arbArray`
-
-``` purescript
-instance arbArray :: (Arbitrary a) => Arbitrary [a]
-```
-
-
-#### `coarbArray`
-
-``` purescript
-instance coarbArray :: (CoArbitrary a) => CoArbitrary [a]
-```
-
-
-#### `Testable`
-
-``` purescript
-class Testable prop where
-  test :: prop -> Gen Result
-```
-
-
-#### `testableResult`
-
-``` purescript
-instance testableResult :: Testable Result
-```
-
-
-#### `testableBoolean`
-
-``` purescript
-instance testableBoolean :: Testable Boolean
-```
-
-
-#### `testableFunction`
-
-``` purescript
-instance testableFunction :: (Arbitrary t, Testable prop) => Testable (t -> prop)
-```
-
-
-#### `quickCheckPure`
-
-``` purescript
-quickCheckPure :: forall prop. (Testable prop) => Number -> Number -> prop -> [Result]
-```
-
-
 #### `QC`
 
 ``` purescript
 type QC a = forall eff. Eff (err :: Exception, random :: Random, trace :: Trace | eff) a
+```
+
+
+#### `quickCheck`
+
+``` purescript
+quickCheck :: forall prop. (Testable prop) => prop -> QC Unit
 ```
 
 
@@ -239,12 +23,21 @@ quickCheck' :: forall prop. (Testable prop) => Number -> prop -> QC Unit
 ```
 
 
-#### `quickCheck`
+#### `quickCheckPure`
 
 ``` purescript
-quickCheck :: forall prop. (Testable prop) => prop -> QC Unit
+quickCheckPure :: forall prop. (Testable prop) => Number -> Number -> prop -> [Result]
 ```
 
+
+#### `(<?>)`
+
+``` purescript
+(<?>) :: Boolean -> String -> Result
+```
+
+Creates a `Result` based on a boolean with a potential failure message for
+when the boolean is `false`.
 
 #### `(===)`
 
@@ -261,6 +54,109 @@ Self-documenting equality assertion
 ```
 
 Self-documenting inequality assertion
+
+
+## Module Test.QuickCheck.Arbitrary
+
+#### `Arbitrary`
+
+``` purescript
+class Arbitrary t where
+  arbitrary :: Gen t
+```
+
+
+#### `Coarbitrary`
+
+``` purescript
+class Coarbitrary t where
+  coarbitrary :: forall r. t -> Gen r -> Gen r
+```
+
+
+#### `arbBoolean`
+
+``` purescript
+instance arbBoolean :: Arbitrary Boolean
+```
+
+
+#### `coarbBoolean`
+
+``` purescript
+instance coarbBoolean :: Coarbitrary Boolean
+```
+
+
+#### `arbNumber`
+
+``` purescript
+instance arbNumber :: Arbitrary Number
+```
+
+
+#### `coarbNumber`
+
+``` purescript
+instance coarbNumber :: Coarbitrary Number
+```
+
+
+#### `arbString`
+
+``` purescript
+instance arbString :: Arbitrary String
+```
+
+
+#### `coarbString`
+
+``` purescript
+instance coarbString :: Coarbitrary String
+```
+
+
+#### `arbArray`
+
+``` purescript
+instance arbArray :: (Arbitrary a) => Arbitrary [a]
+```
+
+
+#### `coarbArray`
+
+``` purescript
+instance coarbArray :: (Coarbitrary a) => Coarbitrary [a]
+```
+
+
+#### `arbFunction`
+
+``` purescript
+instance arbFunction :: (Coarbitrary a, Arbitrary b) => Arbitrary (a -> b)
+```
+
+
+#### `coarbFunction`
+
+``` purescript
+instance coarbFunction :: (Arbitrary a, Coarbitrary b) => Coarbitrary (a -> b)
+```
+
+
+#### `arbAlphaNumString`
+
+``` purescript
+instance arbAlphaNumString :: Arbitrary AlphaNumString
+```
+
+
+#### `coarbAlphaNumString`
+
+``` purescript
+instance coarbAlphaNumString :: Coarbitrary AlphaNumString
+```
+
 
 
 ## Module Test.QuickCheck.Gen
@@ -465,4 +361,52 @@ instance bindGen :: Bind Gen
 
 ``` purescript
 instance monadGen :: Monad Gen
+```
+
+
+
+## Module Test.QuickCheck.Testable
+
+#### `Result`
+
+``` purescript
+data Result
+  = Success 
+  | Failed String
+```
+
+
+#### `showResult`
+
+``` purescript
+instance showResult :: Show Result
+```
+
+
+#### `Testable`
+
+``` purescript
+class Testable prop where
+  test :: prop -> Gen Result
+```
+
+
+#### `testableResult`
+
+``` purescript
+instance testableResult :: Testable Result
+```
+
+
+#### `testableBoolean`
+
+``` purescript
+instance testableBoolean :: Testable Boolean
+```
+
+
+#### `testableFunction`
+
+``` purescript
+instance testableFunction :: (Arbitrary t, Testable prop) => Testable (t -> prop)
 ```

--- a/bower.json
+++ b/bower.json
@@ -19,12 +19,6 @@
   "dependencies": {
     "purescript-random": "~0.1.1",
     "purescript-exceptions": "~0.2.2",
-    "purescript-arrays": "~0.3.0",
-    "purescript-strings": "~0.4.2",
-    "purescript-math": "~0.1.0",
-    "purescript-tuples": "~0.3.0",
-    "purescript-either": "~0.1.4",
-    "purescript-maybe": "~0.2.1",
-    "purescript-foldable-traversable": "~0.3.0"
+    "purescript-math": "~0.1.0"
   }
 }

--- a/src/Test/QuickCheck.purs
+++ b/src/Test/QuickCheck.purs
@@ -1,149 +1,18 @@
 module Test.QuickCheck where
 
 import Debug.Trace
-import Control.Bind
-import Control.Monad.Eff
-import Control.Monad.Eff.Random
-import Control.Monad.Eff.Exception
-import Data.Array
-import Data.Tuple
-import Data.Maybe
-import Data.Either
-import Math
-
-import qualified Data.Char as S
-import qualified Data.String as S
-import qualified Data.String.Unsafe as SU
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Random (Random(), random)
+import Control.Monad.Eff.Exception (Exception(), throwException, error)
 
 import Test.QuickCheck.Gen
-
-class Arbitrary t where
-  arbitrary :: Gen t
-
-class CoArbitrary t where
-  coarbitrary :: forall r. t -> Gen r -> Gen r
-
-data Result = Success | Failed String
-
-instance showResult :: Show Result where
-  show Success = "Success"
-  show (Failed msg) = "Failed: " ++ msg
-
-(<?>) :: Boolean -> String -> Result
-(<?>) true _ = Success
-(<?>) false msg = Failed msg
-
-instance arbChar :: Arbitrary S.Char where
-  arbitrary = S.fromCharCode <<< ((*) 65535) <$> uniform
-
-instance coarbChar :: CoArbitrary S.Char where
-  coarbitrary c = coarbitrary $ S.toCharCode c
-
-instance arbNumber :: Arbitrary Number where
-  arbitrary = uniform
-
-instance coarbNumber :: CoArbitrary Number where
-  coarbitrary = perturbGen
-
-instance arbBoolean :: Arbitrary Boolean where
-  arbitrary = do
-    n <- uniform
-    return $ (n * 2) < 1
-
-instance coarbBoolean :: CoArbitrary Boolean where
-  coarbitrary true = perturbGen 1
-  coarbitrary false = perturbGen 2
-
-instance arbString :: Arbitrary String where
-  arbitrary = S.fromCharArray <$> arbitrary
-
-instance coarbString :: CoArbitrary String where
-  coarbitrary s = coarbitrary $ (S.charCodeAt 0 <$> S.split "" s)
-
-newtype AlphaNumString = AlphaNumString String
-
-instance arbAlphaNumString :: Arbitrary AlphaNumString where
-  arbitrary = do
-    arrNum <- arbitrary
-    return $ AlphaNumString <<< S.fromCharArray $ lookup <$> arrNum where
-      chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-      lookup x = SU.charAt index chars where
-        index = round $ x * (S.length chars - 1)
-
-instance coarbAlphaNumString :: CoArbitrary AlphaNumString where
-  coarbitrary (AlphaNumString s) = coarbitrary s
-
-instance arbTuple :: (Arbitrary a, Arbitrary b) => Arbitrary (Tuple a b) where
-  arbitrary = Tuple <$> arbitrary <*> arbitrary
-
-instance coarbTuple :: (CoArbitrary a, CoArbitrary b) => CoArbitrary (Tuple a b) where
-  coarbitrary (Tuple a b) = coarbitrary a >>> coarbitrary b
-
-instance arbEither :: (Arbitrary a, Arbitrary b) => Arbitrary (Either a b) where
-  arbitrary = do
-    b <- arbitrary
-    if b then Left <$> arbitrary else Right <$> arbitrary
-
-instance coarbEither :: (CoArbitrary a, CoArbitrary b) => CoArbitrary (Either a b) where
-  coarbitrary (Left a)  = coarbitrary a
-  coarbitrary (Right b) = coarbitrary b
-
-instance arbMaybe :: (Arbitrary a) => Arbitrary (Maybe a) where
-  arbitrary = do
-    b <- arbitrary
-    if b then pure Nothing else Just <$> arbitrary
-
-instance coarbMaybe :: (CoArbitrary a) => CoArbitrary (Maybe a) where
-  coarbitrary Nothing = perturbGen 1
-  coarbitrary (Just a) = coarbitrary a
-
-instance arbFunction :: (CoArbitrary a, Arbitrary b) => Arbitrary (a -> b) where
-  arbitrary = repeatable (\a -> coarbitrary a arbitrary)
-
-instance coarbFunction :: (Arbitrary a, CoArbitrary b) => CoArbitrary (a -> b) where
-  coarbitrary f gen = do
-    xs <- arbitrary
-    coarbitrary (map f xs) gen
-
-instance arbArray :: (Arbitrary a) => Arbitrary [a] where
-  arbitrary = do
-    b <- arbitrary
-    if b then return [] else do
-      a <- arbitrary
-      as <- arbitrary
-      return (a : as)
-
-instance coarbArray :: (CoArbitrary a) => CoArbitrary [a] where
-  coarbitrary [] = id
-  coarbitrary (x : xs) = coarbitrary xs <<< coarbitrary x
-
-class Testable prop where
-  test :: prop -> Gen Result
-
-instance testableResult :: Testable Result where
-  test = return
-
-instance testableBoolean :: Testable Boolean where
-  test true = return Success
-  test false = return $ Failed "Test returned false"
-
-instance testableFunction :: (Arbitrary t, Testable prop) => Testable (t -> prop) where
-  test f = do
-    t <- arbitrary
-    test (f t)
-
-quickCheckPure :: forall prop. (Testable prop) => Number -> Number -> prop -> [Result]
-quickCheckPure s = quickCheckPure' {newSeed: s, size: 10} where
-  quickCheckPure' st n prop = evalGen (go n) st
-    where
-    go n | n <= 0 = return []
-    go n = do
-      result <- test prop
-      rest <- go (n - 1)
-      return $ result : rest
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Testable
 
 type QC a = forall eff. Eff (trace :: Trace, random :: Random, err :: Exception | eff) a
+
+quickCheck :: forall prop. (Testable prop) => prop -> QC Unit
+quickCheck prop = quickCheck' 100 prop
 
 quickCheck' :: forall prop. (Testable prop) => Number -> prop -> QC Unit
 quickCheck' n prop = do
@@ -165,17 +34,26 @@ quickCheck' n prop = do
   countSuccesses (Success : rest) = 1 + countSuccesses rest
   countSuccesses (_ : rest) = countSuccesses rest
 
-quickCheck :: forall prop. (Testable prop) => prop -> QC Unit
-quickCheck prop = quickCheck' 100 prop
+quickCheckPure :: forall prop. (Testable prop) => Number -> Number -> prop -> [Result]
+quickCheckPure s = quickCheckPure' {newSeed: s, size: 10} where
+  quickCheckPure' st n prop = evalGen (go n) st
+    where
+    go n | n <= 0 = return []
+    go n = do
+      result <- test prop
+      rest <- go (n - 1)
+      return $ result : rest
+
+-- | Creates a `Result` based on a boolean with a potential failure message for
+-- | when the boolean is `false`.
+(<?>) :: Boolean -> String -> Result
+(<?>) true _ = Success
+(<?>) false msg = Failed msg
 
 -- | Self-documenting equality assertion
 (===) :: forall a b. (Eq a, Show a) => a -> a -> Result
-(===) a b = a == b <?> msg
-  where
-    msg = show a ++ " /= " ++ show b
+(===) a b = a == b <?> show a ++ " /= " ++ show b
 
 -- | Self-documenting inequality assertion
 (/==) :: forall a b. (Eq a, Show a) => a -> a -> Result
-(/==) a b = a /= b <?> msg
-  where
-    msg = show a ++ " == " ++ show b
+(/==) a b = a /= b <?> show a ++ " == " ++ show b

--- a/src/Test/QuickCheck/Arbitrary.purs
+++ b/src/Test/QuickCheck/Arbitrary.purs
@@ -1,0 +1,121 @@
+module Test.QuickCheck.Arbitrary
+  ( Arbitrary, arbitrary
+  , Coarbitrary, coarbitrary
+  ) where
+
+import Data.Function (Fn2(), runFn2)
+import Test.QuickCheck.Gen (Gen(), uniform, perturbGen, repeatable)
+
+class Arbitrary t where
+  arbitrary :: Gen t
+
+class Coarbitrary t where
+  coarbitrary :: forall r. t -> Gen r -> Gen r
+
+instance arbBoolean :: Arbitrary Boolean where
+  arbitrary = do
+    n <- uniform
+    return $ (n * 2) < 1
+
+instance coarbBoolean :: Coarbitrary Boolean where
+  coarbitrary true = perturbGen 1
+  coarbitrary false = perturbGen 2
+
+instance arbNumber :: Arbitrary Number where
+  arbitrary = uniform
+
+instance coarbNumber :: Coarbitrary Number where
+  coarbitrary = perturbGen
+
+instance arbString :: Arbitrary String where
+  arbitrary = do
+    arrNum <- arbitrary
+    return $ fromCharArray $ fromCharCode <<< (* 65535) <$> arrNum
+
+instance coarbString :: Coarbitrary String where
+  coarbitrary s = coarbitrary $ (charCode <$> split s)
+
+instance arbArray :: (Arbitrary a) => Arbitrary [a] where
+  arbitrary = do
+    b <- arbitrary
+    if b then return [] else do
+      a <- arbitrary
+      as <- arbitrary
+      return (a : as)
+
+instance coarbArray :: (Coarbitrary a) => Coarbitrary [a] where
+  coarbitrary [] = id
+  coarbitrary (x : xs) = coarbitrary xs <<< coarbitrary x
+
+instance arbFunction :: (Coarbitrary a, Arbitrary b) => Arbitrary (a -> b) where
+  arbitrary = repeatable (\a -> coarbitrary a arbitrary)
+
+instance coarbFunction :: (Arbitrary a, Coarbitrary b) => Coarbitrary (a -> b) where
+  coarbitrary f gen = do
+    xs <- arbitrary
+    coarbitrary (map f xs) gen
+
+newtype AlphaNumString = AlphaNumString String
+
+instance arbAlphaNumString :: Arbitrary AlphaNumString where
+  arbitrary = do
+    arrNum <- arbitrary
+    return $ AlphaNumString <<< fromCharArray $ lookup <$> arrNum
+      where
+      chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+      lookup x = runFn2 charAt index chars
+        where
+        index = round $ x * (length chars - 1)
+
+instance coarbAlphaNumString :: Coarbitrary AlphaNumString where
+  coarbitrary (AlphaNumString s) = coarbitrary s
+
+foreign import round
+  """
+  var round = Math.round;
+  """ :: Number -> Number
+
+foreign import length
+  """
+  function length(s) {
+    return s.length;
+  }
+  """ :: String -> Number
+
+foreign import charAt
+  """
+  function charAt(i, s) {
+    return s.charAt(i);
+  }
+  """ :: Fn2 Number String String
+
+foreign import fromCharArray
+  """
+  function fromCharArray(a) {
+    return a.join("");
+  }
+  """ :: [String] -> String
+
+foreign import fromCharCode
+  """
+  function fromCharCode(c) {
+    return String.fromCharCode(c);
+  }
+  """ :: Number -> String
+
+foreign import charCode
+  """
+  function charCode(s) {
+    return s.charCodeAt(0);
+  }
+  """ :: String -> Number
+
+foreign import split
+  """
+  function split(s) {
+    return s.split("");
+  }
+  """ :: String -> [String]
+
+map :: forall a b. (a -> b) -> [a] -> [b]
+map = (<$>)

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -4,37 +4,13 @@ module Test.QuickCheck.Gen
   , GenOut()
   , Size()
   , LCG()
-  , repeatable
-  , stateful
-  , variant
-  , sized
-  , resize
-  , choose
-  , chooseInt
-  , oneOf
-  , frequency
-  , arrayOf
-  , arrayOf1
-  , vectorOf
-  , elements
   , runGen
   , evalGen
   , perturbGen
+  , repeatable
+  , stateful
   , uniform
-  , showSample
-  , showSample'
   ) where
-
-import Control.Monad.Eff
-import Control.Monad.Eff.Random
-import Debug.Trace
-import Data.Maybe
-import Data.Tuple
-import Data.Foldable
-import Data.Traversable
-import Data.Monoid.Additive
-import qualified Data.Array as A
-import qualified Math as M
 
 type LCG = Number
 type Size = Number
@@ -45,78 +21,17 @@ type GenOut a = { state :: GenState, value :: a }
 
 data Gen a = Gen (GenState -> GenOut a)
 
-repeatable :: forall a b. (a -> Gen b) -> Gen (a -> b)
-repeatable f = Gen $ \s -> { value: \a -> (runGen (f a) s).value, state: s }
-
-stateful :: forall a. (GenState -> Gen a) -> Gen a
-stateful f = Gen (\s -> runGen (f s) s)
-
-variant :: forall a. LCG -> Gen a -> Gen a
-variant n g = Gen $ \s -> runGen g s { newSeed = n }
-
-sized :: forall a. (Size -> Gen a) -> Gen a
-sized f = stateful (\s -> f s.size)
-
-resize :: forall a. Size -> Gen a -> Gen a
-resize sz g = Gen $ \s -> runGen g s { size = sz }
-
-choose :: Number -> Number -> Gen Number
-choose a b = (*) (max - min) >>> (+) min <$> uniform where
-  min = M.min a b
-  max = M.max a b
-
-chooseInt :: Number -> Number -> Gen Number
-chooseInt a b = M.floor <$> choose (M.ceil a) (M.floor b + 0.999999999)
-
-oneOf :: forall a. Gen a -> [Gen a] -> Gen a
-oneOf x xs = do
-  n <- chooseInt 0 (A.length xs)
-  if n == 0 then x else fromMaybe x (xs A.!! (n - 1))
-
-frequency :: forall a. Tuple Number (Gen a) -> [Tuple Number (Gen a)] -> Gen a
-frequency x xs = let
-    xxs   = x : xs
-    total = runAdditive $ fold (((Additive <<< fst) <$> xxs) :: [Additive Number])
-    pick n d [] = d
-    pick n d ((Tuple k x) : xs) = if n <= k then x else pick (n - k) d xs
-  in do
-    n <- chooseInt 1 total
-    pick n (snd x) xxs
-
-arrayOf :: forall a. Gen a -> Gen [a]
-arrayOf g = sized $ \n ->
-  do k <- chooseInt 0 n
-     vectorOf k g
-
-arrayOf1 :: forall a. Gen a -> Gen (Tuple a [a])
-arrayOf1 g = sized $ \n ->
-  do k  <- chooseInt 0 n
-     x  <- g
-     xs <- vectorOf (k - 1) g
-     return $ Tuple x xs
-
-vectorOf :: forall a. Number -> Gen a -> Gen [a]
-vectorOf k g = sequence $ const g <$> (A.range 1 k)
-
-elements :: forall a. a -> [a] -> Gen a
-elements x xs = do
-  n <- chooseInt 0 (A.length xs)
-  pure if n == 0 then x else fromMaybe x (xs A.!! (n - 1))
-
 runGen :: forall a. Gen a -> GenState -> GenOut a
 runGen (Gen f) = f
 
 evalGen :: forall a. Gen a -> GenState -> a
 evalGen gen st = (runGen gen st).value
 
-sample :: forall r a. Size -> Gen a -> [a]
-sample sz g = evalGen (vectorOf sz g) { newSeed: 0, size: sz }
+repeatable :: forall a b. (a -> Gen b) -> Gen (a -> b)
+repeatable f = Gen $ \s -> { value: \a -> (runGen (f a) s).value, state: s }
 
-showSample' :: forall r a. (Show a) => Size -> Gen a -> Eff (trace :: Trace | r) Unit
-showSample' n g = print $ sample n g
-
-showSample :: forall r a. (Show a) => Gen a -> Eff (trace :: Trace | r) Unit
-showSample = showSample' 10
+stateful :: forall a. (GenState -> Gen a) -> Gen a
+stateful f = Gen (\s -> runGen (f s) s)
 
 --
 -- Magic Numbers
@@ -142,13 +57,15 @@ uniform :: Gen Number
 uniform = (\n -> n / (1 `shl` 30)) <$> lcgStep
 
 foreign import float32ToInt32
-  "function float32ToInt32(n) {\
-  \  var arr = new ArrayBuffer(4);\
-  \  var fv = new Float32Array(arr);\
-  \  var iv = new Int32Array(arr);\
-  \  fv[0] = n;\
-  \  return iv[0];\
-  \}" :: Number -> Number
+  """
+  function float32ToInt32(n) {
+    var arr = new ArrayBuffer(4);
+    var fv = new Float32Array(arr);
+    var iv = new Int32Array(arr);
+    fv[0] = n;
+    return iv[0];
+  }
+  """ :: Number -> Number
 
 perturbGen :: forall a. Number -> Gen a -> Gen a
 perturbGen n (Gen f) = Gen $ \s -> f (s { newSeed = lcgNext (float32ToInt32 n) + s.newSeed })

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -1,29 +1,28 @@
 module Test.QuickCheck.Gen
-  (
-    Gen(),
-    GenState(),
-    GenOut(),
-    Size(),
-    LCG(),
-    repeatable,
-    stateful,
-    variant,
-    sized,
-    resize,
-    choose,
-    chooseInt,
-    oneOf,
-    frequency,
-    arrayOf,
-    arrayOf1,
-    vectorOf,
-    elements,
-    runGen,
-    evalGen,
-    perturbGen,
-    uniform,
-    showSample,
-    showSample'
+  ( Gen()
+  , GenState()
+  , GenOut()
+  , Size()
+  , LCG()
+  , repeatable
+  , stateful
+  , variant
+  , sized
+  , resize
+  , choose
+  , chooseInt
+  , oneOf
+  , frequency
+  , arrayOf
+  , arrayOf1
+  , vectorOf
+  , elements
+  , runGen
+  , evalGen
+  , perturbGen
+  , uniform
+  , showSample
+  , showSample'
   ) where
 
 import Control.Monad.Eff

--- a/src/Test/QuickCheck/Testable.purs
+++ b/src/Test/QuickCheck/Testable.purs
@@ -1,0 +1,25 @@
+module Test.QuickCheck.Testable where
+
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Gen
+
+data Result = Success | Failed String
+
+instance showResult :: Show Result where
+  show Success = "Success"
+  show (Failed msg) = "Failed: " ++ msg
+
+class Testable prop where
+  test :: prop -> Gen Result
+
+instance testableResult :: Testable Result where
+  test = return
+
+instance testableBoolean :: Testable Boolean where
+  test true = return Success
+  test false = return $ Failed "Test returned false"
+
+instance testableFunction :: (Arbitrary t, Testable prop) => Testable (t -> prop) where
+  test f = do
+    t <- arbitrary
+    test (f t)


### PR DESCRIPTION
If we wanted to make QC as minimal as possible, this is probably it.

I guess we'd perhaps want this as `purescript-quickcheck-core` or something, and then have `purescript-quickcheck` pull it in and define most of the rest of the stuff I deleted, aside from the `Arbitrary` instances which can now move out to `purescript-tuples`, `purescript-maybe`, `purescript-either`, and so on.

Unfortunately to do this, I had to copy a bunch of stuff out of `purescript-strings` for the `String` `Arbitrary` instances, as if we add a dependency on that it also pulls in `purescript-maybe`.

Likewise I had to reimplement `map` for `Array` - thinking about it, the `Functor`, `Apply`, ... instances for `Array` are technically orphans at the moment, as they're not defined with `Array` (it's in `Prim`), and nor are they defined with `Functor`, etc. in the Prelude.