### PR TITLE
Adjust LCG parameters

### DIFF
--- a/docs/Test/QuickCheck.md
+++ b/docs/Test/QuickCheck.md
@@ -49,7 +49,7 @@ representing the number of tests which should be run.
 #### `quickCheckPure`
 
 ``` purescript
-quickCheckPure :: forall prop. (Testable prop) => Int -> Int -> prop -> List Result
+quickCheckPure :: forall prop. (Testable prop) => Seed -> Int -> prop -> List Result
 ```
 
 Test a property, returning all test results as an array.

--- a/docs/Test/QuickCheck/Gen.md
+++ b/docs/Test/QuickCheck/Gen.md
@@ -191,7 +191,7 @@ Sample a random generator, using a randomly generated seed
 #### `randomSample`
 
 ``` purescript
-randomSample :: forall r a. Gen a -> Eff (console :: CONSOLE, random :: RANDOM | r) (Array a)
+randomSample :: forall r a. Gen a -> Eff (random :: RANDOM | r) (Array a)
 ```
 
 Get a random sample of 10 values

--- a/docs/Test/QuickCheck/Gen.md
+++ b/docs/Test/QuickCheck/Gen.md
@@ -172,21 +172,29 @@ evalGen :: forall a. Gen a -> GenState -> a
 
 Run a random generator, keeping only the randomly-generated result
 
-#### `showSample'`
+#### `sample`
 
 ``` purescript
-showSample' :: forall r a. (Show a) => Size -> Gen a -> Eff (console :: CONSOLE | r) Unit
+sample :: forall r a. Seed -> Size -> Gen a -> Array a
 ```
 
-Print a random sample to the console
+Sample a random generator
 
-#### `showSample`
+#### `randomSample'`
 
 ``` purescript
-showSample :: forall r a. (Show a) => Gen a -> Eff (console :: CONSOLE | r) Unit
+randomSample' :: forall r a. Size -> Gen a -> Eff (random :: RANDOM | r) (Array a)
 ```
 
-Print a random sample of 10 values to the console
+Sample a random generator, using a randomly generated seed
+
+#### `randomSample`
+
+``` purescript
+randomSample :: forall r a. Gen a -> Eff (console :: CONSOLE, random :: RANDOM | r) (Array a)
+```
+
+Get a random sample of 10 values
 
 #### `uniform`
 

--- a/docs/Test/QuickCheck/LCG.md
+++ b/docs/Test/QuickCheck/LCG.md
@@ -1,11 +1,5 @@
 ## Module Test.QuickCheck.LCG
 
-#### `Seed`
-
-``` purescript
-type Seed = Int
-```
-
 #### `lcgM`
 
 ``` purescript
@@ -28,12 +22,15 @@ The *increment*: a magic constant for the linear congruential generator
 lcgN :: Int
 ```
 
-The *modulus*: a magic constant for the linear congruential generator
+The *modulus*: a magic constant for the linear congruential generator.
+It is equal to 2^31 - 1, a Mersenne prime. It is useful for this value to
+be prime, because then the requirement of the initial seed being coprime
+to the modulus is satisfied when the seed is between 1 and lcgN - 1.
 
 #### `lcgNext`
 
 ``` purescript
-lcgNext :: Int -> Int
+lcgNext :: Seed -> Seed
 ```
 
 Step the linear congruential generator
@@ -45,5 +42,33 @@ randomSeed :: forall e. Eff (random :: RANDOM | e) Seed
 ```
 
 Create a random seed
+
+#### `Seed`
+
+``` purescript
+newtype Seed
+```
+
+A seed for the linear congruential generator. We omit a `Semiring`
+instance because there is no `zero` value, as 0 is not an acceptable
+seed for the generator.
+
+##### Instances
+``` purescript
+instance showSeed :: Show Seed
+instance eqSeed :: Eq Seed
+```
+
+#### `mkSeed`
+
+``` purescript
+mkSeed :: Int -> Seed
+```
+
+#### `runSeed`
+
+``` purescript
+runSeed :: Seed -> Int
+```
 
 

--- a/docs/Test/QuickCheck/LCG.md
+++ b/docs/Test/QuickCheck/LCG.md
@@ -12,7 +12,7 @@ type Seed = Int
 lcgM :: Int
 ```
 
-A magic constant for the linear congruential generator
+The *multiplier*: a magic constant for the linear congruential generator
 
 #### `lcgC`
 
@@ -20,7 +20,7 @@ A magic constant for the linear congruential generator
 lcgC :: Int
 ```
 
-A magic constant for the linear congruential generator
+The *increment*: a magic constant for the linear congruential generator
 
 #### `lcgN`
 
@@ -28,7 +28,7 @@ A magic constant for the linear congruential generator
 lcgN :: Int
 ```
 
-A magic constant for the linear congruential generator
+The *modulus*: a magic constant for the linear congruential generator
 
 #### `lcgNext`
 

--- a/src/Test/QuickCheck.purs
+++ b/src/Test/QuickCheck.purs
@@ -65,7 +65,7 @@ quickCheck' n prop = do
 -- |
 -- | The first argument is the _random seed_ to be passed to the random generator.
 -- | The second argument is the number of tests to run.
-quickCheckPure :: forall prop. (Testable prop) => Int -> Int -> prop -> List Result
+quickCheckPure :: forall prop. (Testable prop) => Seed -> Int -> prop -> List Result
 quickCheckPure s n prop = evalGen (replicateM n (test prop)) { newSeed: s, size: 10 }
 
 -- | The `Testable` class represents _testable properties_.

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -165,7 +165,7 @@ randomSample = randomSample' 10
 -- | A random generator which simply outputs the current seed
 lcgStep :: Gen Int
 lcgStep = Gen f where
-  f s = { value: s.newSeed, state: s { newSeed = lcgNext s.newSeed } }
+  f s = { value: runSeed s.newSeed, state: s { newSeed = lcgNext s.newSeed } }
 
 -- | A random generator which approximates a uniform random variable on `[0, 1]`
 uniform :: Gen Number
@@ -175,7 +175,9 @@ foreign import float32ToInt32 :: Number -> Int
 
 -- | Perturb a random generator by modifying the current seed
 perturbGen :: forall a. Number -> Gen a -> Gen a
-perturbGen n (Gen f) = Gen $ \s -> f (s { newSeed = lcgNext (float32ToInt32 n) + s.newSeed })
+perturbGen n (Gen f) = Gen $ \s -> f (s { newSeed = perturb s.newSeed })
+  where
+  perturb oldSeed = mkSeed (runSeed (lcgNext (mkSeed (float32ToInt32 n))) + runSeed oldSeed)
 
 instance functorGen :: Functor Gen where
   map f (Gen g) = Gen $ \s -> case g s of

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -30,7 +30,6 @@ module Test.QuickCheck.Gen
 import Prelude
 
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Console (CONSOLE(), print)
 import Control.Monad.Eff.Random (RANDOM())
 import Data.Array ((!!), length, range)
 import Data.Foldable (fold)
@@ -160,7 +159,7 @@ randomSample' n g = do
   return $ sample seed n g
 
 -- | Get a random sample of 10 values
-randomSample :: forall r a. Gen a -> Eff (console :: CONSOLE, random :: RANDOM | r) (Array a)
+randomSample :: forall r a. Gen a -> Eff (random :: RANDOM | r) (Array a)
 randomSample = randomSample' 10
 
 -- | A random generator which simply outputs the current seed

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -32,8 +32,25 @@ lcgN = 1 `shl` 31 - 1
 
 -- | Step the linear congruential generator
 lcgNext :: Int -> Int
-lcgNext n = U.fromJust $ fromNumber $ (toNumber lcgM * toNumber n + toNumber lcgC) % toNumber lcgN
+lcgNext n = U.fromJust $ fromNumber $ (toNumber lcgM * n' + toNumber lcgC) % toNumber lcgN
+  where
+  -- Ensure that the input is between seedMin and seedMax; the LCG will not
+  -- work well for other inputs.
+  n' = ensureBetween (toNumber seedMin) (toNumber seedMax) (toNumber n)
+
+ensureBetween :: Number -> Number -> Number -> Number
+ensureBetween min max n =
+  let rangeSize = max - min
+  in (((n % rangeSize) + rangeSize) % rangeSize) + min
 
 -- | Create a random seed
 randomSeed :: forall e. Eff (random :: RANDOM | e) Seed
-randomSeed = randomInt 1 lcgM
+randomSeed = randomInt seedMin seedMax
+
+-- | The minimum permissible Seed value.
+seedMin :: Seed
+seedMin = 1
+
+-- | The maximum permissible Seed value.
+seedMax :: Seed
+seedMax = lcgM - 1

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -26,9 +26,12 @@ lcgM = 48271
 lcgC :: Int
 lcgC = 0
 
--- | The *modulus*: a magic constant for the linear congruential generator
+-- | The *modulus*: a magic constant for the linear congruential generator.
+-- | It is equal to 2^31 - 1, a Mersenne prime. It is useful for this value to
+-- | be prime, because then the requirement of the initial seed being coprime
+-- | to the modulus is satisfied when the seed is between 1 and lcgN - 1.
 lcgN :: Int
-lcgN = 1 `shl` 31 - 1
+lcgN = 2147483647
 
 -- | Step the linear congruential generator
 lcgNext :: Int -> Int

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -13,9 +13,7 @@ import Math ((%))
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Random (RANDOM(), randomInt)
 import Data.Int (fromNumber, toNumber)
-import Data.Int.Bits (shl, (.|.))
-import Data.Array (replicate)
-import Data.Foldable (product)
+import Data.Int.Bits (shl)
 import qualified Data.Maybe.Unsafe as U
 
 type Seed = Int
@@ -30,7 +28,7 @@ lcgC = 0
 
 -- | The *modulus*: a magic constant for the linear congruential generator
 lcgN :: Int
-lcgN = product (replicate 31 2) - 1
+lcgN = 1 `shl` 31 - 1
 
 -- | Step the linear congruential generator
 lcgNext :: Int -> Int

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -13,7 +13,7 @@ import Math ((%))
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Random (RANDOM(), randomInt)
 import Data.Int (fromNumber, toNumber)
-import Data.Int.Bits (shl)
+import Data.Int.Bits (shl, (.|.))
 import Data.Array (replicate)
 import Data.Foldable (product)
 import qualified Data.Maybe.Unsafe as U
@@ -38,4 +38,9 @@ lcgNext n = U.fromJust $ fromNumber $ (toNumber lcgM * toNumber n + toNumber lcg
 
 -- | Create a random seed
 randomSeed :: forall e. Eff (random :: RANDOM | e) Seed
-randomSeed = randomInt 0 lcgM
+randomSeed =
+  -- Because the increment is 0, we must ensure that any seed is coprime to the
+  -- modulus. Luckily, this is easy: the modulus has just one prime factor, 2,
+  -- so this means our seed will be coprime to the modulus iff it is odd.
+  -- We ensure oddness by perfoming a bitwise OR with 1.
+  randomInt 0 lcgM <#> (.|. 1)

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -14,21 +14,23 @@ import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Random (RANDOM(), randomInt)
 import Data.Int (fromNumber, toNumber)
 import Data.Int.Bits (shl)
+import Data.Array (replicate)
+import Data.Foldable (product)
 import qualified Data.Maybe.Unsafe as U
 
 type Seed = Int
 
--- | A magic constant for the linear congruential generator
+-- | The *multiplier*: a magic constant for the linear congruential generator
 lcgM :: Int
-lcgM = 1103515245
+lcgM = 48271
 
--- | A magic constant for the linear congruential generator
+-- | The *increment*: a magic constant for the linear congruential generator
 lcgC :: Int
-lcgC = 12345
+lcgC = 0
 
--- | A magic constant for the linear congruential generator
+-- | The *modulus*: a magic constant for the linear congruential generator
 lcgN :: Int
-lcgN = one `shl` 30
+lcgN = product (replicate 31 2) - 1
 
 -- | Step the linear congruential generator
 lcgNext :: Int -> Int

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -38,9 +38,4 @@ lcgNext n = U.fromJust $ fromNumber $ (toNumber lcgM * toNumber n + toNumber lcg
 
 -- | Create a random seed
 randomSeed :: forall e. Eff (random :: RANDOM | e) Seed
-randomSeed =
-  -- Because the increment is 0, we must ensure that any seed is coprime to the
-  -- modulus. Luckily, this is easy: the modulus has just one prime factor, 2,
-  -- so this means our seed will be coprime to the modulus iff it is odd.
-  -- We ensure oddness by perfoming a bitwise OR with 1.
-  randomInt 0 lcgM <#> (.|. 1)
+randomSeed = randomInt 1 lcgM


### PR DESCRIPTION
Refs #32, /cc @sharkdp

This commit uses the same parameters as C++11's `minstd_rand`, which has a
much smaller multiplier, meaning that faults due to bad precision are
~~much less likely~~ no longer possible. *edit: The largest possible value
for the seed is the modulus, `2^31 - 1`, and multiplying this by the new
multiplier gives the correct result.*

Also, I modified the sampling API exported by Test.QuickCheck.Gen. Now
that psci supports printing stuff to the console, returning the actual
values seems more useful (as you can do stuff with them, like summing an
array of numbers, for example).

An example with the new parameters:

    > map sum $ randomSample' 5000 $ chooseInt 0 2
    2533