### PR TITLE
Better Arbitrary Array instance

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.purs
+++ b/src/Test/QuickCheck/Arbitrary.purs
@@ -2,7 +2,6 @@ module Test.QuickCheck.Arbitrary where
 
 import Prelude
 
-import Data.Array ((:))
 import Data.Char (toCharCode, fromCharCode)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -80,12 +79,7 @@ instance coarbOrdering :: Coarbitrary Ordering where
   coarbitrary GT = perturbGen 3.0
 
 instance arbArray :: (Arbitrary a) => Arbitrary (Array a) where
-  arbitrary = do
-    b <- arbitrary
-    if b then return [] else do
-      a <- arbitrary
-      as <- arbitrary
-      return (a : as)
+  arbitrary = arrayOf arbitrary
 
 instance coarbArray :: (Coarbitrary a) => Coarbitrary (Array a) where
   coarbitrary = foldl (\f x -> f <<< coarbitrary x) id

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -127,7 +127,9 @@ arrayOf1 g = sized $ \n ->
 
 -- | Create a random generator which generates a vector of random values of a specified size.
 vectorOf :: forall a. Int -> Gen a -> Gen (Array a)
-vectorOf k g = sequence $ const g <$> range one k
+vectorOf k g
+  | k <= 0    = return []
+  | otherwise = sequence $ const g <$> range one k
 
 -- | Create a random generator which selects a value from a non-empty collection with
 -- | uniform probability.


### PR DESCRIPTION
The Arbitrary Array instance now depends on the Gen's size parameter; if
the size is n, then the number of elements in a generated array should
be equally likely to be any number from 0 up to n-1.

This also fixes #35, a bug where vectorOf 0 x would contain exactly 2
elements rather than 0. This needed to be fixed to ensure that an
`arbitrary :: Gen (Array a)` is capable of producing empty arrays.