### PR TITLE
Stack safe gen (StateT)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-exceptions": "^0.3.0",
     "purescript-lists": "^0.7.0",
     "purescript-random": "^0.2.0",
-    "purescript-strings": "^0.7.0"
+    "purescript-strings": "^0.7.0",
+    "purescript-transformers": "^0.6.1"
   }
 }

--- a/docs/Test/QuickCheck/Gen.md
+++ b/docs/Test/QuickCheck/Gen.md
@@ -20,32 +20,15 @@ type GenState = { newSeed :: Seed, size :: Size }
 
 The state of the random generator monad
 
-#### `GenOut`
-
-``` purescript
-type GenOut a = { state :: GenState, value :: a }
-```
-
-The output of the random generator monad
-
 #### `Gen`
 
 ``` purescript
-data Gen a
+type Gen a = State GenState a
 ```
 
 The random generator monad
 
 `Gen` is a state monad which encodes a linear congruential generator.
-
-##### Instances
-``` purescript
-instance functorGen :: Functor Gen
-instance applyGen :: Apply Gen
-instance applicativeGen :: Applicative Gen
-instance bindGen :: Bind Gen
-instance monadGen :: Monad Gen
-```
 
 #### `repeatable`
 
@@ -139,6 +122,14 @@ arrayOf1 :: forall a. Gen a -> Gen (Tuple a (Array a))
 
 Create a random generator which generates a non-empty array of random values.
 
+#### `listOf`
+
+``` purescript
+listOf :: forall a. Int -> Gen a -> Gen (List a)
+```
+
+Create a random generator which generates a list of random values of the specified size.
+
 #### `vectorOf`
 
 ``` purescript
@@ -159,7 +150,7 @@ uniform probability.
 #### `runGen`
 
 ``` purescript
-runGen :: forall a. Gen a -> GenState -> GenOut a
+runGen :: forall a. Gen a -> GenState -> Tuple a GenState
 ```
 
 Run a random generator

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -15,6 +15,7 @@ module Test.QuickCheck.Gen
   , frequency
   , arrayOf
   , arrayOf1
+  , listOf
   , vectorOf
   , elements
   , runGen

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,6 +2,9 @@
 module Test.Main where
 
 import Prelude
+import Control.Bind
+import Data.Array (head)
+import Data.Maybe.Unsafe (fromJust)
 import Data.Foldable
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Arbitrary
@@ -9,15 +12,14 @@ import Control.Monad.Eff.Console
 
 main = do
   log "Try with some little Gens first"
-  print $ go 10
-  print $ go 100
-  print $ go 1000
-  print $ go 10000
+  print =<< go 10
+  print =<< go 100
+  print =<< go 1000
+  print =<< go 10000
 
   log "Testing stack safety of Gen"
-  print $ go 20000
+  print =<< go 20000
 
   where
-  go n = sum $ _.value $ runGen (getVector n) state
-  getVector n = vectorOf n (arbitrary :: Gen Int)
-  state = { newSeed: 0, size: 100 }
+  go n = map (sum <<< unsafeHead) $ randomSample' 1 (vectorOf n (arbitrary :: Gen Int))
+  unsafeHead = fromJust <<< head

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -19,6 +19,7 @@ main = do
 
   log "Testing stack safety of Gen"
   print =<< go 20000
+  print =<< go 100000
 
   where
   go n = map (sum <<< unsafeHead) $ randomSample' 1 (vectorOf n (arbitrary :: Gen Int))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,23 @@
+
+module Test.Main where
+
+import Prelude
+import Data.Foldable
+import Test.QuickCheck.Gen
+import Test.QuickCheck.Arbitrary
+import Control.Monad.Eff.Console
+
+main = do
+  log "Try with some little Gens first"
+  print $ go 10
+  print $ go 100
+  print $ go 1000
+  print $ go 10000
+
+  log "Testing stack safety of Gen"
+  print $ go 20000
+
+  where
+  go n = sum $ _.value $ runGen (getVector n) state
+  getVector n = vectorOf n (arbitrary :: Gen Int)
+  state = { newSeed: 0, size: 100 }


### PR DESCRIPTION
Refs #30, #29. Use `tailrec` to make `vectorOf` stack safe. Also export `listOf`, which will probably be useful.

Although `vectorOf` is now stack safe, `replicateM` will still overflow for a sufficiently large size. Perhaps `replicateMRec` should go into `tailrec`, and then we could direct people to use `replicateMRec` where necessary?

Alternatively, the formulation in #30 based on `Trampoline` doesn't have this problem. I haven't been able to find a way to make the `Trampoline` version stack overflow, even with `replicateM`. (@jdegoes, can you think of an example that might?)