### PR TITLE
Stack safe gen (Trampoline)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-exceptions": "~0.3.0",
     "purescript-lists": "~0.7.0",
     "purescript-random": "~0.2.0",
-    "purescript-strings": "~0.5.0"
+    "purescript-strings": "~0.5.0",
+    "purescript-free": "~0.5.0"
   }
 }

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -169,7 +169,7 @@ randomSample = randomSample' 10
 -- | A random generator which simply outputs the current seed
 lcgStep :: Gen Int
 lcgStep = Gen f where
-  f s = done { value: s.newSeed, state: s { newSeed = lcgNext s.newSeed } }
+  f s = done { value: runSeed s.newSeed, state: s { newSeed = lcgNext s.newSeed } }
 
 -- | A random generator which approximates a uniform random variable on `[0, 1]`
 uniform :: Gen Number

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,15 @@
+
+module Test.Main where
+
+import Prelude
+import Data.Foldable
+import Test.QuickCheck.Gen
+import Test.QuickCheck.Arbitrary
+import Control.Monad.Eff.Console
+
+main = do
+  log "Testing stack safety of Gen"
+  print $ sum $ _.value $ runGen gen state
+  where
+  gen = vectorOf 20000 (arbitrary :: Gen Int)
+  state = { newSeed: 0, size: 100 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,14 +2,25 @@
 module Test.Main where
 
 import Prelude
+import Control.Bind
+import Data.Array (head)
+import Data.Maybe.Unsafe (fromJust)
 import Data.Foldable
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Arbitrary
 import Control.Monad.Eff.Console
 
 main = do
+  log "Try with some little Gens first"
+  print =<< go 10
+  print =<< go 100
+  print =<< go 1000
+  print =<< go 10000
+
   log "Testing stack safety of Gen"
-  print $ sum $ _.value $ runGen gen state
+  print =<< go 20000
+  print =<< go 100000
+
   where
-  gen = vectorOf 20000 (arbitrary :: Gen Int)
-  state = { newSeed: 0, size: 100 }
+  go n = map (sum <<< unsafeHead) $ randomSample' 1 (vectorOf n (arbitrary :: Gen Int))
+  unsafeHead = fromJust <<< head


### PR DESCRIPTION
For consideration as an alternative to #37. This is safe to use with `replicateM`, whereas you have to use `replicateMRec` with the other version. However, it is also quite a lot slower. The tests here take 11.1 seconds to run, whereas the tests in #37 (which are the same) take 3.5 seconds.