### PR TITLE
Higher rank Arbitrary and Coarbitrary classes

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.purs
+++ b/src/Test/QuickCheck/Arbitrary.purs
@@ -108,11 +108,11 @@ instance arb1Array :: Arbitrary1 Array where
 instance coarb1Array :: Coarbitrary1 Array where
   coarbitrary1 = foldl (\f x -> f <<< coarbitrary x) id
 
-instance arbFunction :: (Coarbitrary a, Arbitrary b) => Arbitrary (a -> b) where
-  arbitrary = repeatable (\a -> coarbitrary a arbitrary)
+instance arb1Function :: (Coarbitrary a) => Arbitrary1 ((->) a) where
+  arbitrary1 = repeatable (\a -> coarbitrary a arbitrary)
 
-instance coarbFunction :: (Arbitrary a, Coarbitrary b) => Coarbitrary (a -> b) where
-  coarbitrary f gen = do
+instance coarb1Function :: (Arbitrary a) => Coarbitrary1 ((->) a) where
+  coarbitrary1 f gen = do
     xs <- arbitrary
     coarbitrary (map f (xs :: Array a)) gen
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Bind
 import Data.Array (head)
 import Data.Maybe.Unsafe (fromJust)
+import Data.Either (Either())
 import Data.Foldable
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Arbitrary
@@ -20,6 +21,12 @@ main = do
   log "Testing stack safety of Gen"
   print =<< go 20000
   print =<< go 100000
+
+  a <- randomSample arbitrary
+  print (a :: Array Boolean)
+
+  b <- randomSample arbitrary
+  print (b :: Array (Either Char Boolean))
 
   where
   go n = map (sum <<< unsafeHead) $ randomSample' 1 (vectorOf n (arbitrary :: Gen Int))


### PR DESCRIPTION
I'm looking at QC-laws again, it seems these classes would be useful generically, not just in there.

Maybe should port over `eq1` and `eq2` too?

The `arbArbitrary1` and `arb1Arbitrary2` give us `Arbitrary` and `Arbitrary1` instance for every `Arbitrary2` "for free" and won't result in overlaps as long as no attempt is made to implement the lower-rank versions for a type that has the higher-rank instance.