### PR TITLE
Gradually increase Gen size in `sample`

### DIFF
--- a/docs/Test/QuickCheck/Arbitrary.md
+++ b/docs/Test/QuickCheck/Arbitrary.md
@@ -28,6 +28,9 @@ instance arbFunction :: (Coarbitrary a, Arbitrary b) => Arbitrary (a -> b)
 instance arbTuple :: (Arbitrary a, Arbitrary b) => Arbitrary (Tuple a b)
 instance arbMaybe :: (Arbitrary a) => Arbitrary (Maybe a)
 instance arbEither :: (Arbitrary a, Arbitrary b) => Arbitrary (Either a b)
+instance arbitraryList :: (Arbitrary a) => Arbitrary (List a)
+instance arbitraryIdentity :: (Arbitrary a) => Arbitrary (Identity a)
+instance arbitraryLazy :: (Arbitrary a) => Arbitrary (Lazy a)
 ```
 
 #### `Coarbitrary`
@@ -60,6 +63,9 @@ instance coarbFunction :: (Arbitrary a, Coarbitrary b) => Coarbitrary (a -> b)
 instance coarbTuple :: (Coarbitrary a, Coarbitrary b) => Coarbitrary (Tuple a b)
 instance coarbMaybe :: (Coarbitrary a) => Coarbitrary (Maybe a)
 instance coarbEither :: (Coarbitrary a, Coarbitrary b) => Coarbitrary (Either a b)
+instance coarbList :: (Coarbitrary a) => Coarbitrary (List a)
+instance coarbIdentity :: (Coarbitrary a) => Coarbitrary (Identity a)
+instance coarbLazy :: (Coarbitrary a) => Coarbitrary (Lazy a)
 ```
 
 

--- a/docs/Test/QuickCheck/Gen.md
+++ b/docs/Test/QuickCheck/Gen.md
@@ -166,10 +166,11 @@ Run a random generator, keeping only the randomly-generated result
 #### `sample`
 
 ``` purescript
-sample :: forall r a. Seed -> Size -> Gen a -> Array a
+sample :: forall r a. Seed -> Int -> Gen a -> Array a
 ```
 
-Sample a random generator
+Sample a random generator, using the given seed and producing a sample
+containing the given number of values.
 
 #### `randomSample'`
 

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -40,7 +40,7 @@ import Data.Foldable (fold)
 import Data.Int (fromNumber, toNumber)
 import Data.Maybe (fromMaybe)
 import Data.Monoid.Additive (Additive(..), runAdditive)
-import Data.Traversable (sequence)
+import Data.Traversable (sequence, traverse)
 import Data.Tuple (Tuple(..), fst, snd)
 import Data.Either (Either(..))
 import Data.List (List(..), fromList)
@@ -160,9 +160,13 @@ runGen = runState
 evalGen :: forall a. Gen a -> GenState -> a
 evalGen = evalState
 
--- | Sample a random generator
-sample :: forall r a. Seed -> Size -> Gen a -> Array a
-sample seed sz g = evalGen (vectorOf sz g) { newSeed: seed, size: sz }
+-- | Sample a random generator, using the given seed and producing a sample
+-- | containing the given number of values.
+sample :: forall r a. Seed -> Int -> Gen a -> Array a
+sample seed n g = evalGen sampleGen { newSeed: seed, size: 0 }
+  where
+  sampleGen = traverse (flip resize g) sizes
+  sizes = range 0 (n - 1) <#> (*2)
 
 -- | Sample a random generator, using a randomly generated seed
 randomSample' :: forall r a. Size -> Gen a -> Eff (random :: RANDOM | r) (Array a)


### PR DESCRIPTION
At the moment, the `Size` parameter of `sample` is used not only for the
number of values that you want to get back, but also for the size
parameter for the `GenState`. This is not ideal, as often you want to
change one without affecting the other.

This commit changes this behaviour so that the parameter is now written
as `Int` instead, and affects only the number of values which are
produced. The Size parameter now starts at 0 and is incremented in
steps of 2, just like in the Haskell version.
