### PR TITLE
Prepare for 2.0 release

### DIFF
--- a/src/Test/QuickCheck.purs
+++ b/src/Test/QuickCheck.purs
@@ -22,6 +22,7 @@ module Test.QuickCheck
   , quickCheckPure
   , class Testable
   , test
+  , Space
   , Result(..)
   , withHelp
   , (<?>)
@@ -35,20 +36,21 @@ import Prelude
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
-import Control.Monad.Eff.Exception (EXCEPTION, throwException, error)
+import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Rec.Class (Step(..), tailRec)
 
-import Data.Foldable (for_)
+import Data.Foldable (fold, foldMap, for_)
 import Data.List (List)
 import Data.Maybe (Maybe(..))
 import Data.Maybe.First (First(..))
 import Data.Monoid (mempty)
+import Data.Newtype (unwrap)
 import Data.Tuple (Tuple(..))
 import Data.Unfoldable (replicateA)
 
-import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
-import Test.QuickCheck.Gen (Gen, evalGen, runGen)
+import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary, shrink)
+import Test.QuickCheck.Gen (evalGen, runGen)
 import Test.QuickCheck.LCG (Seed, randomSeed)
 
 -- | A type synonym which represents the effects used by the `quickCheck` function.
@@ -66,45 +68,116 @@ quickCheck prop = quickCheck' 100 prop
 quickCheck' :: forall eff prop. Testable prop => Int -> prop -> QC eff Unit
 quickCheck' n prop = do
   seed <- randomSeed
-  let result = tailRec loop { seed, index: 0, successes: 0, firstFailure: mempty }
-  log $ show result.successes <> "/" <> show n <> " test(s) passed."
-  for_ result.firstFailure \{ index, message } ->
-    throwException $ error $ "Test " <> show (index + 1) <> " failed: \n" <> message
-  where
-  loop :: LoopState -> Step LoopState (LoopResult ())
-  loop { seed, index, successes, firstFailure }
-    | index == n = Done { successes, firstFailure }
-    | otherwise =
-        case runGen (test prop) { newSeed: seed, size: 10 } of
-          Tuple Success s ->
-            Loop
-              { seed: s.newSeed
-              , index: index + 1
-              , successes: successes + 1
-              , firstFailure
-              }
-          Tuple (Failed message) s ->
-            Loop
-              { seed: s.newSeed
-              , index: index + 1
-              , successes
-              , firstFailure: firstFailure <> First (Just { index, message })
-              }
+  runSpace (test :: Space prop) \try -> do
+    let result = tailRec (loop try) { seed, index: 0, successes: 0, firstFailure: mempty }
+    log $ show result.successes <> "/" <> show n <> " test(s) passed."
+    for_ result.firstFailure \{ index, message, testCase } -> do
+      shrunk <- pure $ tailRec (search try) { index, testCase, message, shrinkCount: 0 }
+      log (fold
+        [ "Test "
+        , show (shrunk.index + 1)
+        , " failed (with "
+        , show shrunk.shrinkCount
+        , " reductions): \n"
+        , shrunk.message
+        ])
 
-type LoopResult r =
+  where
+  loop
+    :: forall a
+     . Arbitrary a
+    => (prop -> a -> Result)
+    -> LoopState a
+    -> Step (LoopState a) (LoopState a)
+  loop try state@{ seed, index, successes, firstFailure }
+    | index == n = Done state
+    | otherwise =
+        case runGen arbitrary { newSeed: seed, size: 10 } of
+          Tuple testCase { newSeed } ->
+            case try prop testCase of
+              Success ->
+                Loop
+                  { seed: newSeed
+                  , index: index + 1
+                  , successes: successes + 1
+                  , firstFailure
+                  }
+              Failed message ->
+                Loop
+                  { seed: newSeed
+                  , index: index + 1
+                  , successes
+                  , firstFailure: firstFailure
+                      <> First (Just { index, message, testCase })
+                  }
+
+  search
+    :: forall a
+     . Arbitrary a
+    => (prop -> a -> Result)
+    -> ShrinkState a
+    -> Step (ShrinkState a) (ShrinkState a)
+  search try state@{ shrinkCount, testCase, index, message } = do
+    case unwrap (foldMap (First <<< tryShrink try) (shrink testCase)) of
+      Just { message: message', testCase: testCase' } | shrinkCount < 100 ->
+        Loop
+          { index
+          , message: message'
+          , shrinkCount: shrinkCount + 1
+          , testCase: testCase'
+          }
+      _ ->
+        Done state
+
+  tryShrink
+    :: forall a
+     . (prop -> a -> Result)
+    -> a
+    -> Maybe { message :: String, testCase :: a }
+  tryShrink try testCase =
+    case try prop testCase of
+      Success -> Nothing
+      Failed message -> Just { message, testCase }
+
+type LoopState a =
   { successes :: Int
-  , firstFailure :: First { index :: Int, message :: String }
-  | r
+  , firstFailure :: First { index :: Int, message :: String, testCase :: a }
+  , seed :: Seed
+  , index :: Int
   }
 
-type LoopState = LoopResult (seed :: Seed, index :: Int)
+type ShrinkState a =
+  { index :: Int
+  , message :: String
+  , shrinkCount :: Int
+  , testCase :: a
+  }
 
 -- | Test a property, returning all test results as an array.
 -- |
 -- | The first argument is the _random seed_ to be passed to the random generator.
 -- | The second argument is the number of tests to run.
 quickCheckPure :: forall prop. Testable prop => Seed -> Int -> prop -> List Result
-quickCheckPure s n prop = evalGen (replicateA n (test prop)) { newSeed: s, size: 10 }
+quickCheckPure s n prop = runSpace (test :: Space prop) \f ->
+  evalGen (replicateA n (f prop <$> arbitrary)) { newSeed: s, size: 10 }
+
+-- | A `Space` for some property is defined by an `Arbitrary` instance which
+-- | provides the arguments for that property, returning a `Result`.
+-- |
+-- | This is used to collect function arguments into a nested `Tuple` in the
+-- | `Testable` instances.
+-- |
+-- | A `Space` can be explored to find minimal failing test cases by iteratively
+-- | `shrink`ing a failing case.
+newtype Space prop = Space (forall r. (forall a. Arbitrary a => (prop -> a -> Result) -> r) -> r)
+
+runSpace :: forall prop r. Space prop -> (forall a. Arbitrary a => (prop -> a -> Result) -> r) -> r
+runSpace (Space f) g = f g
+
+-- | Create a `Space` by providing a function which applies a property to
+-- | its arguments.
+space :: forall prop a. Arbitrary a => (prop -> a -> Result) -> Space prop
+space f = Space \toR -> toR f
 
 -- | The `Testable` class represents _testable properties_.
 -- |
@@ -113,17 +186,20 @@ quickCheckPure s n prop = evalGen (replicateA n (test prop)) { newSeed: s, size:
 -- |
 -- | Testable properties can be passed to the `quickCheck` function.
 class Testable prop where
-  test :: prop -> Gen Result
+  test :: Space prop
 
 instance testableResult :: Testable Result where
-  test = pure
+  test = space \result (_ :: Unit) -> result
 
 instance testableBoolean :: Testable Boolean where
-  test true = pure Success
-  test false = pure $ Failed "Test returned false"
+  test = space \success (_ :: Unit) ->
+    if success
+      then Success
+      else Failed "Test returned false"
 
 instance testableFunction :: (Arbitrary t, Testable prop) => Testable (t -> prop) where
-  test f = arbitrary >>= test <<< f
+  test = runSpace (test :: Space prop) \f ->
+    space \g (Tuple t a) -> f (g t) a
 
 -- | The result of a test: success or failure (with an error message).
 data Result = Success | Failed String

--- a/src/Test/QuickCheck/Data/AlphaNumString.purs
+++ b/src/Test/QuickCheck/Data/AlphaNumString.purs
@@ -8,7 +8,7 @@ import Data.Newtype (class Newtype)
 import Data.String (fromCharArray, toCharArray)
 
 import Test.QuickCheck.Gen (Gen, arrayOf, oneOf)
-import Test.QuickCheck.Arbitrary (class Coarbitrary, class Arbitrary, coarbitrary)
+import Test.QuickCheck.Arbitrary (class Coarbitrary, class Arbitrary, coarbitrary, defaultShrink)
 
 -- | A newtype for `String` whose `Arbitrary` instance generated random
 -- | alphanumeric strings.
@@ -24,6 +24,7 @@ instance arbAlphaNumString :: Arbitrary AlphaNumString where
 
     anyChar :: Gen Char
     anyChar = oneOf (pure 'a') (map pure rest)
+  shrink = defaultShrink
 
 instance coarbAlphaNumString :: Coarbitrary AlphaNumString where
   coarbitrary (AlphaNumString s) = coarbitrary s

--- a/src/Test/QuickCheck/LCG.purs
+++ b/src/Test/QuickCheck/LCG.purs
@@ -58,7 +58,7 @@ seedMin = 1
 
 -- | The maximum permissible Seed value.
 seedMax :: Int
-seedMax = lcgM - 1
+seedMax = lcgN - 1
 
 -- | A seed for the linear congruential generator. We omit a `Semiring`
 -- | instance because there is no `zero` value, as 0 is not an acceptable
@@ -73,8 +73,11 @@ runSeed (Seed x) = x
 
 ensureBetween :: Int -> Int -> Int -> Int
 ensureBetween min max n =
-  let rangeSize = max - min
-  in (((n `mod` rangeSize) + rangeSize) `mod` rangeSize) + min
+  let
+    rangeSize = max - min
+    n' = n `mod` rangeSize
+  in
+    if n' < min then n' + max else n'
 
 instance showSeed :: Show Seed where
   show (Seed x) = "Seed " <> show x


### PR DESCRIPTION
- Resolves #56 
- The failing seed is now printed
- You can run QC with a particular seed now
- The LCG seed clamping was completely jacked up, probably making the randomness horrible as well as making it impossible to run QC with a seed that it originally produced while failing

I failed miserably at writing a `Testable prop => Testable (Gen prop)` - with this new `Space` stuff I have no clue at all what is supposed to happen now, so you'll have to add that one!