### PR TITLE
[BREAKING] Use NonEmpty

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "purescript-lists": "^3.0.0",
     "purescript-random": "^2.0.0",
     "purescript-strings": "^2.0.0",
-    "purescript-transformers": "^2.0.0"
+    "purescript-transformers": "^2.0.0",
+    "purescript-nonempty": "3.0.0"
   }
 }

--- a/src/Test/QuickCheck/Arbitrary.purs
+++ b/src/Test/QuickCheck/Arbitrary.purs
@@ -18,6 +18,7 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (wrap)
 import Data.String (charCodeAt, fromCharArray, split)
 import Data.Tuple (Tuple(..))
+import Data.NonEmpty ((:|))
 
 import Test.QuickCheck.Gen (Gen, listOf, chooseInt, sized, perturbGen, repeatable, arrayOf, oneOf, uniform)
 
@@ -81,7 +82,7 @@ instance coarbUnit :: Coarbitrary Unit where
   coarbitrary _ = perturbGen 1.0
 
 instance arbOrdering :: Arbitrary Ordering where
-  arbitrary = oneOf (pure LT) [pure EQ, pure GT]
+  arbitrary = oneOf $ (pure LT) :| [pure EQ, pure GT]
 
 instance coarbOrdering :: Coarbitrary Ordering where
   coarbitrary LT = perturbGen 1.0

--- a/src/Test/QuickCheck/Data/AlphaNumString.purs
+++ b/src/Test/QuickCheck/Data/AlphaNumString.purs
@@ -6,6 +6,7 @@ import Prelude
 
 import Data.Newtype (class Newtype)
 import Data.String (fromCharArray, toCharArray)
+import Data.NonEmpty ((:|))
 
 import Test.QuickCheck.Gen (Gen, arrayOf, oneOf)
 import Test.QuickCheck.Arbitrary (class Coarbitrary, class Arbitrary)
@@ -25,6 +26,6 @@ instance arbAlphaNumString :: Arbitrary AlphaNumString where
     rest = toCharArray "bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
     anyChar :: Gen Char
-    anyChar = oneOf (pure 'a') (map pure rest)
+    anyChar = oneOf $ (pure 'a') :| (map pure rest)
 
 derive newtype instance coarbAlphaNumString :: Coarbitrary AlphaNumString

--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -48,6 +48,7 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (unwrap)
 import Data.Tuple (Tuple(..), fst, snd)
+import Data.NonEmpty (NonEmpty, (:|))
 
 import Math as M
 
@@ -173,10 +174,10 @@ listOf = replicateMRec
 vectorOf :: forall a. Int -> Gen a -> Gen (Array a)
 vectorOf k g = toUnfoldable <$> listOf k g
 
--- | Create a random generator which selects a value from a non-empty collection with
+-- | Create a random generator which selects a value from a non-empty array with
 -- | uniform probability.
-elements :: forall a. a -> Array a -> Gen a
-elements x xs = do
+elements :: forall a. NonEmpty Array a -> Gen a
+elements (x :| xs) = do
   n <- chooseInt zero (length xs)
   pure if n == zero then x else fromMaybe x (xs !! (n - one))
 


### PR DESCRIPTION
We introduce a dependency on `purescript-nonempty` and use the provided type wherever it is called for.