### PR TITLE
Arbitrary instances for NonEmpty

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "purescript-lists": "^3.0.0",
     "purescript-random": "^2.0.0",
     "purescript-strings": "^2.0.0",
-    "purescript-transformers": "^2.0.0"
+    "purescript-transformers": "^2.0.0",
+    "purescript-nonempty": "^3.0.0"
   }
 }

--- a/src/Test/QuickCheck/Arbitrary.purs
+++ b/src/Test/QuickCheck/Arbitrary.purs
@@ -14,8 +14,10 @@ import Data.Identity (Identity(..))
 import Data.Int (toNumber)
 import Data.Lazy (Lazy, defer, force)
 import Data.List (List)
+import Data.List.NonEmpty (NonEmptyList(..))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (wrap)
+import Data.NonEmpty (NonEmpty(..))
 import Data.String (charCodeAt, fromCharArray, split)
 import Data.Tuple (Tuple(..))
 
@@ -143,3 +145,15 @@ instance arbitraryLazy :: Arbitrary a => Arbitrary (Lazy a) where
 
 instance coarbLazy :: Coarbitrary a => Coarbitrary (Lazy a) where
   coarbitrary a = coarbitrary (force a)
+
+instance arbNonEmpty :: (Arbitrary (f a), Arbitrary a) => Arbitrary (NonEmpty f a) where
+  arbitrary = NonEmpty <$> arbitrary <*> arbitrary
+
+instance coarbNonEmpty :: (Coarbitrary (f a), Coarbitrary a) => Coarbitrary (NonEmpty f a) where
+  coarbitrary (NonEmpty head tail) = coarbitrary head >>> coarbitrary tail
+
+instance arbNonEmptyList :: Arbitrary a => Arbitrary (NonEmptyList a) where
+  arbitrary = NonEmptyList <$> arbitrary
+
+instance coarbNonEmptyList :: Coarbitrary a => Coarbitrary (NonEmptyList a) where
+  coarbitrary (NonEmptyList nel) = coarbitrary nel


### PR DESCRIPTION
We were transitively dependent on purescript-nonempty through
purescript-lists, so we might as well define the appropriate instances here.