### PR TITLE
let chooseInt work with differences greater than 2^31

### DIFF
--- a/src/Test/QuickCheck/Gen.purs
+++ b/src/Test/QuickCheck/Gen.purs
@@ -123,7 +123,8 @@ chooseInt' :: Int -> Int -> Gen Int
 chooseInt' a b = floor <<< clamp <$> choose32BitPosNumber
   where
     choose32BitPosNumber :: Gen Number
-    choose32BitPosNumber = (+) <$> choose31BitPosNumber <*> choose31BitPosNumber
+    choose32BitPosNumber =
+      (+) <$> choose31BitPosNumber <*> (((*) 2.0) <$> choose31BitPosNumber)
 
     choose31BitPosNumber :: Gen Number
     choose31BitPosNumber = toNumber <$> lcgStep


### PR DESCRIPTION
Fixes #71 

Please read the issue above for more details on the problem.

This is the most conservative, non-breaking fix to the issue I could think of. It basically does what we were doing before, but converts the `Int`s to `Number`s to work its magic, and steps the LCG twice in order to hide a 32 bit `Int` inside a `Number`.

The branch here has a very simple test you can run with `pulp test` to see that it does indeed work: https://github.com/matthewleon/purescript-quickcheck/tree/test-chooseInt32