### PR TITLE
Add 'Arbitrary' instance for records

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,9 @@
     "purescript-random": "^3.0.0",
     "purescript-strings": "^3.0.0",
     "purescript-transformers": "^3.0.0",
-    "purescript-generics-rep": "^5.0.0"
+    "purescript-generics-rep": "^5.0.0",
+    "purescript-typelevel-prelude": "^2.4.0",
+    "purescript-record": "^0.2.0"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -46,6 +46,11 @@ main = do
   log "Generating via Generic"
   logShow =<< randomSample' 10 (arbitrary :: Gen (Foo Int))
 
+  log "Arbitrary instance for records"
+  listOfRecords ← randomSample' 10 (arbitrary :: Gen { foo :: Int, nested :: { bar :: Boolean } })
+  let toString rec = "{ foo: " <> show rec.foo <> "; nested.bar: " <> show rec.nested.bar <> " }"
+  logShow (toString <$> listOfRecords)
+
   quickCheck \(x :: Int) -> x <? x + 1
   quickCheck \(x :: Int) -> x <=? x + 1
   quickCheck \(x :: Int) -> x >=? x - 1


### PR DESCRIPTION
This adds an `Arbitrary` instance for general records:

Example
``` purs
type Person =
  { name :: { first :: String
            , last :: String
            }
  , age :: Int
  , height :: Number
  }

> persons ← randomSample' 10 (arbitrary :: Gen Person)
```

*Note*: This is the first time that I'm using the new (and awesome) typelevel-programming features of PureScript, so I'm not sure if I'm doing this correctly :smile: