### PR TITLE
Arbitrary instances for NonEmpty*

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-arrays": "^4.0.0",
+    "purescript-arrays": "^4.3.0",
     "purescript-console": "^3.0.0",
     "purescript-either": "^3.0.0",
     "purescript-enums": "^3.0.0",
@@ -30,7 +30,7 @@
     "purescript-nonempty": "^4.0.0",
     "purescript-partial": "^1.2.0",
     "purescript-random": "^3.0.0",
-    "purescript-strings": "^3.0.0",
+    "purescript-strings": "^3.5.0",
     "purescript-transformers": "^3.0.0",
     "purescript-generics-rep": "^5.0.0",
     "purescript-typelevel-prelude": "^2.4.0",


### PR DESCRIPTION
Arbitrary and Coarbitrary for NonEmptyArray and NonEmptyString.

fixes https://github.com/purescript/purescript-quickcheck/issues/90