### PR TITLE
fixing genericCoarbitrary

### DIFF
--- a/src/Test/QuickCheck/Arbitrary.purs
+++ b/src/Test/QuickCheck/Arbitrary.purs
@@ -240,8 +240,8 @@ genericArbitrary :: forall a rep. Generic a rep => Arbitrary rep => Gen a
 genericArbitrary = to <$> (arbitrary :: Gen rep)
 
 -- | A `Generic` implementation of the `coarbitrary` member from the `Coarbitrary` type class.
-genericCoarbitrary :: forall a rep. Generic a rep => Coarbitrary rep => a -> Gen a -> Gen a
-genericCoarbitrary x g = to <$> coarbitrary (from x) (from <$> g)
+genericCoarbitrary :: forall a rep t. Generic a rep => Coarbitrary rep => a -> Gen t -> Gen t
+genericCoarbitrary x = coarbitrary (from x)
 
 -- | A helper typeclass to implement `Arbitrary` for records.
 class ArbitraryRowList list row | list -> row where


### PR DESCRIPTION
`coarbitrary` is intended to perturb an unrelated `Gen` with data that implements the typeclass - it's not intended to be explicitly related to the generated data.