### PR TITLE
Replace NonEmpty Array and NonEmpty List by NonEmptyArray and NonEmptyList

### DIFF
--- a/src/Test/QuickCheck/Gen.js
+++ b/src/Test/QuickCheck/Gen.js
@@ -1,4 +1,4 @@
-/* global exports, ArrayBuffer, Float32Array, Int32Array */
+/* global ArrayBuffer, Float32Array, Int32Array */
 "use strict";
 
 // module Test.QuickCheck.Gen


### PR DESCRIPTION
The issue doesn’t suggest to replace `NonEmpty List` by `NonEmptyList` in `frequency` but I thought it would be better for consistency. I’m happy to revert that if isn’t wanted.

Close https://github.com/purescript/purescript-quickcheck/issues/109.