### PR TITLE
stack safety for quickCheckPure and quickCheckPure'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- `quickCheckPure` and `quickCheckPure'` stack safety (#127)
 
 Other improvements:
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -17,9 +17,11 @@ import Data.Number (isFinite)
 import Partial.Unsafe (unsafePartial)
 import Random.LCG (mkSeed)
 import Test.Assert (assert)
-import Test.QuickCheck (class Testable, quickCheck, (/=?), (<=?), (<?), (==?), (>=?), (>?))
+import Test.QuickCheck (class Testable, quickCheck, quickCheckPure', (/=?), (<=?), (<?), (==?), (>=?), (>?))
 import Test.QuickCheck.Arbitrary (arbitrary, genericArbitrary, class Arbitrary)
 import Test.QuickCheck.Gen (Gen, Size, randomSample, randomSample', resize, runGen, sized, vectorOf)
+import Data.Maybe (Maybe(..))
+import Data.List as List
 
 data Foo a = F0 a | F1 a a | F2 { foo :: a, bar :: Array a }
 derive instance genericFoo :: Generic (Foo a) _
@@ -85,6 +87,12 @@ main = do
   quickCheckFail $ 4 ==? 3
   quickCheck     $ 4 >?  3
   quickCheckFail $ 4 <=? 3
+
+  log "Testing stack safety of quickCheckPure'"
+  let n = 100_000
+  let pairs  = quickCheckPure' (mkSeed 1234) n \(x :: Int) -> x <? x + 1
+  assert (Just (mkSeed 1234) /= map fst (List.last pairs))
+  log ("Completed " <> show n <> " runs.")
 
   log "Checking that chooseFloat over the whole Number range always yields a finite value"
   randomSample (MGen.chooseFloat ((-1.7976931348623157e+308)) (1.7976931348623157e+308)) >>= assert <<< all isFinite


### PR DESCRIPTION
**Description of the change**

Fixes https://github.com/purescript/purescript-quickcheck/issues/126

I used `tailRec` similar to how `quickCheckWithSeed` does.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
